### PR TITLE
[FEAT] : 특정 식단 상세 조회 API 구현

### DIFF
--- a/src/main/java/umc7th/bulk/dailyMeal/exception/DailyMealErrorCode.java
+++ b/src/main/java/umc7th/bulk/dailyMeal/exception/DailyMealErrorCode.java
@@ -1,0 +1,17 @@
+package umc7th.bulk.dailyMeal.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import umc7th.bulk.global.error.BaseErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum DailyMealErrorCode implements BaseErrorCode {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "DAILY_MEAL_NOT_FOUND", "해당 Id의 하루 식단이 존재하지 않습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/umc7th/bulk/dailyMeal/exception/DailyMealException.java
+++ b/src/main/java/umc7th/bulk/dailyMeal/exception/DailyMealException.java
@@ -1,0 +1,10 @@
+package umc7th.bulk.dailyMeal.exception;
+
+import umc7th.bulk.global.error.BaseErrorCode;
+import umc7th.bulk.global.error.exception.CustomException;
+
+public class DailyMealException extends CustomException {
+    public DailyMealException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/umc7th/bulk/dailyMeal/repository/DailyMealRepository.java
+++ b/src/main/java/umc7th/bulk/dailyMeal/repository/DailyMealRepository.java
@@ -1,0 +1,7 @@
+package umc7th.bulk.dailyMeal.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc7th.bulk.dailyMeal.entity.DailyMeal;
+
+public interface DailyMealRepository extends JpaRepository<DailyMeal, Long> {
+}

--- a/src/main/java/umc7th/bulk/meal/controller/MealController.java
+++ b/src/main/java/umc7th/bulk/meal/controller/MealController.java
@@ -1,0 +1,33 @@
+package umc7th.bulk.meal.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc7th.bulk.global.apiPayload.CustomResponse;
+import umc7th.bulk.global.success.GeneralSuccessCode;
+import umc7th.bulk.meal.dto.MealResponseDTO;
+import umc7th.bulk.meal.entity.MealType;
+import umc7th.bulk.meal.service.query.MealQueryService;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "식단 관련 컨트롤러")
+@RequestMapping("/api/menu")
+public class MealController {
+
+    private final MealQueryService mealQueryService;
+
+    @GetMapping("/{dailyMealId}")
+    @Operation(method = "GET", summary = "식단 상세 조회 API")
+    public CustomResponse<?> getMealById(
+            @PathVariable("dailyMealId") Long dailyMealId,
+            @RequestParam MealType type,
+            @RequestParam(name = "cursorId", required = false) Long cursorId,
+            @RequestParam(name = "pageSize", defaultValue = "2") int pageSize) {
+
+        MealResponseDTO.MealPreviewDTO mealItems = mealQueryService.getMealItems(dailyMealId, type, cursorId, pageSize);
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, mealItems);
+    }
+
+}

--- a/src/main/java/umc7th/bulk/meal/dto/MealDTO.java
+++ b/src/main/java/umc7th/bulk/meal/dto/MealDTO.java
@@ -4,7 +4,10 @@ import lombok.Getter;
 import umc7th.bulk.meal.entity.Meal;
 import umc7th.bulk.meal.entity.MealType;
 import umc7th.bulk.mealItem.dto.MealItemDTO;
+import umc7th.bulk.mealItem.entity.MealItem;
+import umc7th.bulk.mealMealItemMapping.entity.MealMealItemMapping;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,19 +24,47 @@ public class MealDTO {
 
         public MealInfoDTO(Meal meal) {
             type = meal.getType();
-            mealItems = meal.getMealItems().stream()
-                    .map(mealItem -> new MealItemDTO.MealItemInfoDTO(mealItem))
+
+            // meamMealItemMapping에서 item들 뽑고 dto 리스트로
+            List<MealItem> mealItemList = meal.getMealMealItemMappings().stream()
+                    .map(MealMealItemMapping::getMealItem)
+                    .toList();
+            
+            mealItems = mealItemList.stream()
+                    .map(MealItemDTO.MealItemInfoDTO::new)
                     .collect(Collectors.toList());
 
-            mealCalories = meal.getMealItems().stream()
-                    .mapToLong(mealItemsCalories -> mealItemsCalories.getCalories()).sum();
-            mealCarbos = meal.getMealItems().stream()
-                    .mapToLong(mealItemsCarbos -> mealItemsCarbos.getCarbos()).sum();
-            mealProteins = meal.getMealItems().stream()
-                    .mapToLong(mealItemsProteins -> mealItemsProteins.getProteins()).sum();
-            mealFats = meal.getMealItems().stream()
-                    .mapToLong(mealItemsFats -> mealItemsFats.getFats()).sum();
+            mealCalories = mealItemList.stream()
+                    .mapToLong(MealItem::getCalories)
+                    .sum();
+            mealCarbos = mealItemList.stream()
+                    .mapToLong(MealItem::getCarbos)
+                    .sum();
+            mealProteins = mealItemList.stream()
+                    .mapToLong(MealItem::getProteins)
+                    .sum();
+            mealFats = mealItemList.stream()
+                    .mapToLong(MealItem::getFats)
+                    .sum();
+        }
+    }
 
+    @Getter
+    public static class MealSummaryDTO {
+        private LocalDate date;
+        private MealType type;
+        private Long mealCalories;
+        private Long mealCarbos;
+        private Long mealProteins;
+        private Long mealFats;
+
+        public MealSummaryDTO(LocalDate date, MealType type, Long mealCalories, Long mealCarbos, Long mealProteins, Long mealFats) {
+            this.date = date;
+            this.type = type;
+            this.mealCalories = mealCalories;
+            this.mealCarbos = mealCarbos;
+            this.mealProteins = mealProteins;
+            this.mealFats = mealFats;
         }
     }
 }

--- a/src/main/java/umc7th/bulk/meal/dto/MealResponseDTO.java
+++ b/src/main/java/umc7th/bulk/meal/dto/MealResponseDTO.java
@@ -1,0 +1,28 @@
+package umc7th.bulk.meal.dto;
+
+import lombok.*;
+import umc7th.bulk.mealItem.dto.MealItemDTO;
+
+import java.util.List;
+
+public class MealResponseDTO {
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Builder
+    public static class MealPreviewDTO {
+
+        private MealDTO.MealSummaryDTO mealSummary;
+        private List<MealItemDTO.MealItemPreviewDTO> items;
+        private Long nextCursorId;
+
+        public static MealPreviewDTO from(MealDTO.MealSummaryDTO mealSummary, List<MealItemDTO.MealItemPreviewDTO> items, Long nextCursorId) {
+            return MealPreviewDTO.builder()
+                    .mealSummary(mealSummary)
+                    .items(items)
+                    .nextCursorId(nextCursorId)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/umc7th/bulk/meal/entity/Meal.java
+++ b/src/main/java/umc7th/bulk/meal/entity/Meal.java
@@ -5,6 +5,7 @@ import lombok.*;
 import umc7th.bulk.dailyMeal.entity.DailyMeal;
 import umc7th.bulk.global.BaseTimeEntity;
 import umc7th.bulk.mealItem.entity.MealItem;
+import umc7th.bulk.mealMealItemMapping.entity.MealMealItemMapping;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -48,5 +49,5 @@ public class Meal extends BaseTimeEntity { // 식사 정보
 
     @OneToMany(mappedBy = "meal", cascade = CascadeType.ALL)
     @Builder.Default
-    private List<MealItem> mealItems = new ArrayList<>();
+    private List<MealMealItemMapping> mealMealItemMappings = new ArrayList<>();
 }

--- a/src/main/java/umc7th/bulk/meal/service/query/MealQueryService.java
+++ b/src/main/java/umc7th/bulk/meal/service/query/MealQueryService.java
@@ -1,0 +1,10 @@
+package umc7th.bulk.meal.service.query;
+
+import umc7th.bulk.meal.dto.MealResponseDTO;
+import umc7th.bulk.meal.entity.MealType;
+
+public interface MealQueryService {
+
+//    Meal getMeal(Long dailyMealId, MealType mealType, Long cursorId, int pageSize);
+    MealResponseDTO.MealPreviewDTO getMealItems(Long dailyMealId, MealType type, Long cursorId, int pageSize);
+}

--- a/src/main/java/umc7th/bulk/meal/service/query/MealQueryServiceImpl.java
+++ b/src/main/java/umc7th/bulk/meal/service/query/MealQueryServiceImpl.java
@@ -1,0 +1,76 @@
+package umc7th.bulk.meal.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc7th.bulk.dailyMeal.entity.DailyMeal;
+import umc7th.bulk.dailyMeal.exception.DailyMealErrorCode;
+import umc7th.bulk.dailyMeal.exception.DailyMealException;
+import umc7th.bulk.dailyMeal.repository.DailyMealRepository;
+import umc7th.bulk.meal.dto.MealDTO;
+import umc7th.bulk.meal.dto.MealResponseDTO;
+import umc7th.bulk.meal.entity.Meal;
+import umc7th.bulk.meal.entity.MealType;
+import umc7th.bulk.meal.exception.MealErrorCode;
+import umc7th.bulk.meal.exception.MealErrorException;
+import umc7th.bulk.mealItem.dto.MealItemDTO;
+import umc7th.bulk.mealItem.entity.MealItem;
+import umc7th.bulk.mealMealItemMapping.entity.MealMealItemMapping;
+import umc7th.bulk.mealMealItemMapping.repository.MealMealItemMappingRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MealQueryServiceImpl implements MealQueryService{
+
+    private final DailyMealRepository dailyMealRepository;
+    private final MealMealItemMappingRepository mappingRepository;
+    @Override
+    public MealResponseDTO.MealPreviewDTO getMealItems(Long dailyMealId, MealType type, Long cursorId, int pagSize) {
+
+        // 하루 식단 확인
+        DailyMeal dailyMeal = dailyMealRepository.findById(dailyMealId).orElseThrow(
+                () -> new DailyMealException(DailyMealErrorCode.NOT_FOUND));
+        
+        // 끼니 조회
+        Meal meal = dailyMeal.getMeals().stream()
+                .filter(m -> m.getType() == type)
+                .findFirst()
+                .orElseThrow(() -> new MealErrorException(MealErrorCode.NOT_FOUND));
+        Long userId = meal.getDailyMeal().getMealPlan().getUser().getId();
+
+        // MealMealItemMapping 통해 MealItem 가져오기
+        List<MealMealItemMapping> mealItemMappings = mappingRepository.findByMealId(meal.getId());
+        List<MealItem> mealItems = mealItemMappings.stream()
+                .map(mealMealItemMapping -> mealMealItemMapping.getMealItem())
+                .toList();
+        
+        // 칼로리, 탄단지 계산
+        Long mealCalories = mealItems.stream().mapToLong(MealItem::getCalories).sum();
+        Long mealCarbos = mealItems.stream().mapToLong(MealItem::getCarbos).sum();
+        Long mealProteins = mealItems.stream().mapToLong(MealItem::getProteins).sum();
+        Long mealFats = mealItems.stream().mapToLong(MealItem::getFats).sum();
+
+        // Meal 축소본
+        LocalDate date = meal.getDailyMeal().getDate();
+        MealDTO.MealSummaryDTO summaryDTO = new MealDTO.MealSummaryDTO(date, type, mealCalories, mealCarbos, mealProteins, mealFats);
+
+        // Meal의 음식 목록 - 페이지네이션 필요
+        Pageable pageable = PageRequest.of(0, pagSize);
+        Slice<MealMealItemMapping> mappingSlice = mappingRepository.findMealItemsByUserAndMealWithCursor(userId, type, cursorId, pageable);
+
+        List<MealItemDTO.MealItemPreviewDTO> items = mappingSlice.getContent().stream()
+                .map(mapping -> new MealItemDTO.MealItemPreviewDTO(mapping.getMealItem()))
+                .toList();
+
+        Long nextCursorId = (mappingSlice.hasNext() && !items.isEmpty()) ? items.get(items.size() - 1).getId() : null;
+
+        return MealResponseDTO.MealPreviewDTO.from(summaryDTO, items, nextCursorId);
+    }
+}

--- a/src/main/java/umc7th/bulk/mealItem/dto/MealItemDTO.java
+++ b/src/main/java/umc7th/bulk/mealItem/dto/MealItemDTO.java
@@ -14,4 +14,31 @@ public class MealItemDTO {
             name = mealItem.getName();
         }
     }
+
+    @Getter
+    public static class MealItemPreviewDTO {
+        private Long id;
+        private String name;
+        private String unit;
+        private Long gradePeopleNum;
+        private Double grade;
+        private Long calories;
+        private Long carbos;
+        private Long proteins;
+        private Long fats;
+        private Long gram;
+
+        public MealItemPreviewDTO(MealItem mealItem) {
+            id = mealItem.getId();
+            name = mealItem.getName();
+            unit = mealItem.getUnit();
+            gradePeopleNum = mealItem.getGradePeopleNum();
+            grade = mealItem.getGrade();
+            calories = mealItem.getCalories();
+            carbos = mealItem.getCarbos();
+            proteins = mealItem.getProteins();
+            fats = mealItem.getFats();
+            gram = mealItem.getGram();
+        }
+    }
 }

--- a/src/main/java/umc7th/bulk/mealItem/entity/MealItem.java
+++ b/src/main/java/umc7th/bulk/mealItem/entity/MealItem.java
@@ -2,7 +2,10 @@ package umc7th.bulk.mealItem.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import umc7th.bulk.meal.entity.Meal;
+import umc7th.bulk.mealMealItemMapping.entity.MealMealItemMapping;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -34,9 +37,20 @@ public class MealItem { // 각 식사별 음식 정보
     @Column(name = "fats")
     private Long fats;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "meal_id")
-    private Meal meal;
+    @Column(name = "unit", length = 30)
+    private String unit;
+
+    @Column(name = "grade")
+    private Double grade; // 음식 평점
+
+    @Column(name = "grade_people")
+    private Long gradePeopleNum; // 평점 인원
+
+    @OneToMany(mappedBy = "mealItem", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<MealMealItemMapping> mealMealItemMappings = new ArrayList<>();
+
+
 }
 
 

--- a/src/main/java/umc7th/bulk/mealItem/repository/MealItemRepository.java
+++ b/src/main/java/umc7th/bulk/mealItem/repository/MealItemRepository.java
@@ -1,0 +1,27 @@
+package umc7th.bulk.mealItem.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import umc7th.bulk.meal.entity.MealType;
+import umc7th.bulk.mealItem.entity.MealItem;
+
+public interface MealItemRepository extends JpaRepository<MealItem, Long> {
+
+    @Query("SELECT mi FROM MealItem mi " +
+            "JOIN FETCH mi.mealMealItemMappings mmim " +
+            "JOIN FETCH mmim.meal m " +
+            "JOIN FETCH m.dailyMeal dm " +
+            "JOIN FETCH dm.mealPlan mp " +
+            "WHERE mp.user.id = :userId " +
+            "AND m.type = :type " +
+            "AND (:cursorId IS NULL OR mi.id < :cursorId)")
+    Slice<MealItem> findMealItemsByUserAndMealWithCursor(
+            @Param("userId") Long userId,
+            @Param("type") MealType type,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable);
+
+}

--- a/src/main/java/umc7th/bulk/mealMealItemMapping/entity/MealMealItemMapping.java
+++ b/src/main/java/umc7th/bulk/mealMealItemMapping/entity/MealMealItemMapping.java
@@ -1,0 +1,28 @@
+package umc7th.bulk.mealMealItemMapping.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc7th.bulk.meal.entity.Meal;
+import umc7th.bulk.mealItem.entity.MealItem;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MealMealItemMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meal_mealItem_mapping_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meal_id")
+    private Meal meal;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meal_item_id")
+    private MealItem mealItem;
+
+}

--- a/src/main/java/umc7th/bulk/mealMealItemMapping/repository/MealMealItemMappingRepository.java
+++ b/src/main/java/umc7th/bulk/mealMealItemMapping/repository/MealMealItemMappingRepository.java
@@ -1,0 +1,29 @@
+package umc7th.bulk.mealMealItemMapping.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import umc7th.bulk.meal.entity.MealType;
+import umc7th.bulk.mealMealItemMapping.entity.MealMealItemMapping;
+
+import java.util.List;
+
+public interface MealMealItemMappingRepository extends JpaRepository<MealMealItemMapping, Long> {
+
+    // 특정 끼니 해당하는 매핑 리스트
+    List<MealMealItemMapping> findByMealId(Long mealId);
+
+    @Query("SELECT mmim FROM MealMealItemMapping mmim " +
+            "WHERE mmim.meal.dailyMeal.mealPlan.user.id = :userId " +
+            "AND mmim.meal.type = :type " +
+            "AND (:cursorId IS NULL OR :cursorId = 0 OR mmim.mealItem.id >= :cursorId) " +
+            "ORDER BY mmim.mealItem.id ASC ")
+    Slice<MealMealItemMapping> findMealItemsByUserAndMealWithCursor(
+            @Param("userId") Long userId,
+            @Param("type") MealType type,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/umc7th/bulk/mealPlan/controller/MealPlanController.java
+++ b/src/main/java/umc7th/bulk/mealPlan/controller/MealPlanController.java
@@ -19,7 +19,7 @@ public class MealPlanController {
     private final MealPlanQueryService mealPlanQueryService;
     private final UserService userService;
 
-    @GetMapping("/{mealPlanId}")
+    @GetMapping("/mealPlanId")
     public CustomResponse<?> getMealWeekPlan(
             @RequestParam Long userId,
             @RequestParam Long mealPlanId) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #28 

## 📌 개요
- 특정 식단 조회 api를 나타냄

## 🔁 변경 사항
- 일부 엔티티 필드 값 삭제 및 추가
- Meal과 MealItem 간의 양방향 연관관계 끊고 Mapping 엔티티 추가
- 특정 식단 조회 관련 코드
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
