### PR TITLE
[FEAT] 검색 음식 상세 조회 API 구현

### DIFF
--- a/src/main/java/umc7th/bulk/mealItem/controller/MealItemController.java
+++ b/src/main/java/umc7th/bulk/mealItem/controller/MealItemController.java
@@ -39,4 +39,13 @@ public class MealItemController {
         List<MealItemDTO.MealItemPopularityDTO> popularityMealItems = mealItemService.getPopularityMealItems();
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, popularityMealItems);
     }
+
+    // 검색 음식 상세 조회(바텀 팝업)
+    @GetMapping("/{mealItemId}")
+    @Operation(summary = "검색 음식 상세 조회(바텀 팝업 내용)", description = "검색한 음식의 탄단지 및 상세 내용 조회")
+    public CustomResponse<?> getSearchMealItemInfo(@PathVariable Long mealItemId) {
+        List<MealItemDTO.MealItemSearchInfoDTO> searchMealItemInfo = mealItemService.getSearchMealItemInfo(mealItemId);
+
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, searchMealItemInfo);
+    }
 }

--- a/src/main/java/umc7th/bulk/mealItem/dto/MealItemDTO.java
+++ b/src/main/java/umc7th/bulk/mealItem/dto/MealItemDTO.java
@@ -58,4 +58,23 @@ public class MealItemDTO {
             grade = mealItem.getGrade();
         }
     }
+
+    @Getter
+    public static class MealItemSearchInfoDTO {
+        private String name;
+        private Long carbos;
+        private Long proteins;
+        private Long fats;
+        private String unit;
+        private Long gram;
+
+        public MealItemSearchInfoDTO(MealItem mealItem) {
+            this.name = mealItem.getName();
+            this.carbos = mealItem.getCarbos();
+            this.proteins = mealItem.getProteins();
+            this.fats = mealItem.getFats();
+            this.unit = mealItem.getUnit();
+            this.gram = mealItem.getGram();
+        }
+    }
 }

--- a/src/main/java/umc7th/bulk/mealItem/repository/MealItemRepository.java
+++ b/src/main/java/umc7th/bulk/mealItem/repository/MealItemRepository.java
@@ -43,6 +43,4 @@ public interface MealItemRepository extends JpaRepository<MealItem, Long> {
     @Query("SELECT mi FROM MealItem mi ORDER BY mi.recordCount DESC")
     List<MealItem> findTop5MealItemByRecordCount(Pageable pageable);
 
-
-
 }

--- a/src/main/java/umc7th/bulk/mealItem/service/MealItemService.java
+++ b/src/main/java/umc7th/bulk/mealItem/service/MealItemService.java
@@ -10,4 +10,6 @@ public interface MealItemService {
     List<MealItemDTO.MealItemPreviewDTO> searchMealItems(String keyword, Long cursor);
 
     List<MealItemDTO.MealItemPopularityDTO> getPopularityMealItems();
+
+    List<MealItemDTO.MealItemSearchInfoDTO> getSearchMealItemInfo(Long mealItemId);
 }

--- a/src/main/java/umc7th/bulk/mealItem/service/MealItemServiceImpl.java
+++ b/src/main/java/umc7th/bulk/mealItem/service/MealItemServiceImpl.java
@@ -6,9 +6,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import umc7th.bulk.mealItem.dto.MealItemDTO;
 import umc7th.bulk.mealItem.entity.MealItem;
+import umc7th.bulk.mealItem.exception.MealItemErrorCode;
+import umc7th.bulk.mealItem.exception.MealItemErrorException;
 import umc7th.bulk.mealItem.repository.MealItemRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -45,5 +48,13 @@ public class MealItemServiceImpl implements MealItemService{
         return IntStream.range(0, mealItems.size())
                 .mapToObj(k -> new MealItemDTO.MealItemPopularityDTO(mealItems.get(k), k + 1))
                 .toList();
+    }
+
+    @Override
+    public List<MealItemDTO.MealItemSearchInfoDTO> getSearchMealItemInfo(Long mealItemId) {
+        MealItem mealItem = mealItemRepository.findById(mealItemId)
+                .orElseThrow(() -> new MealItemErrorException(MealItemErrorCode.NOT_FOUND));
+
+        return List.of(new MealItemDTO.MealItemSearchInfoDTO(mealItem));
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #

## 📌 개요
- 검색한 음식에 대해 직접 양을 기록하는 바텀 팝업이 존재
- 바텀 팝업에서 해당 음식에 대한 탄단지 등의 기본 정보들 조회하는 API 구현
- '추가하기' 버튼을 위한 API를 구현하고자 했으나, 추가한 다음에 어떤 로직으로 진행되는지 페이지가 없어서 구현 불가능(바로 기록되는지, 리스트에 담겼다가 추가/빼기 등의 작업을 더 할 수 있는지 모름)

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
